### PR TITLE
US888096: Use docker image version management plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <DOCKER_HUB_PUBLIC>${dockerHubPublic}</DOCKER_HUB_PUBLIC>
         <enforceBannedDependencies>false</enforceBannedDependencies>
+        <projectDockerRegistry>opensuse-opensearch2-image-${project.version}.project-registries.local</projectDockerRegistry>
     </properties>
 
     <dependencyManagement>
@@ -150,7 +151,35 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.cafapi.plugins.docker.versions</groupId>
+                    <artifactId>docker-versions-maven-plugin</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>com.github.cafapi.plugins.docker.versions</groupId>
+                <artifactId>docker-versions-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <imageManagement>
+                        <image>
+                            <repository>${dockerHubPublic}/cafapi/opensuse-jre17</repository>
+                            <tag>4.0.0</tag>
+                            <digest>sha256:c0065ce7db226f864099ffd52371ebcf580c944a772f24fc0cb69ccacd9e6059</digest>
+                        </image>
+                        <image>
+                            <repository>${dockerHubPublic}/opensearchproject/opensearch</repository>
+                            <tag>2.14.0</tag>
+                            <digest>sha256:96af4ace999e20f3f74b1675e501d7dba46f2e7c185cfcffd4626898b00e6743</digest>
+                        </image>
+                    </imageManagement>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -14,11 +14,8 @@
 # limitations under the License.
 #
 
-# Docker registry
-ARG DOCKER_HUB_PUBLIC=docker.io
-
 # Reference the official OpenSearch 2 image
-FROM @DOCKER_HUB_PUBLIC@/opensearchproject/opensearch:2.14.0 AS os2-image
+FROM @projectDockerRegistry@/opensearchproject/opensearch AS os2-image
 
 # Remove unused plugins
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer --purge && \
@@ -48,7 +45,7 @@ RUN rm -rf /usr/share/opensearch/jdk \
 #
 # Builder image to install plugins and configure opensearch
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/opensuse-jre17:4 AS builder
+FROM @projectDockerRegistry@/cafapi/opensuse-jre17 AS builder
 
 RUN zypper -n refresh && \
     zypper -n update
@@ -86,7 +83,7 @@ RUN chgrp 0 /usr/share/opensearch/opensearch-docker-entrypoint.sh && \
 #
 # The actual image definition
 #
-FROM @DOCKER_HUB_PUBLIC@/cafapi/opensuse-jre17:4
+FROM @projectDockerRegistry@/cafapi/opensuse-jre17
 
 RUN zypper -n refresh && \
     zypper -n update && \


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=888096

I temporarily reverted this to get it released for 24.2.3, this PR is putting it back again.