### PR TITLE
I941175: Fix project registry name sanitization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
                 <plugin>
                     <groupId>com.github.cafapi.plugins.docker.versions</groupId>
                     <artifactId>docker-versions-maven-plugin</artifactId>
-                    <version>1.1.0-I941175-SNAPSHOT</version>
+                    <version>2.0.0-I941175-SNAPSHOT</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                 <plugin>
                     <groupId>com.github.cafapi.plugins.docker.versions</groupId>
                     <artifactId>docker-versions-maven-plugin</artifactId>
-                    <version>1.0.0-29</version>
+                    <version>1.1.0-SNAPSHOT</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                 <plugin>
                     <groupId>com.github.cafapi.plugins.docker.versions</groupId>
                     <artifactId>docker-versions-maven-plugin</artifactId>
-                    <version>1.1.0-SNAPSHOT</version>
+                    <version>1.1.0-I941175-SNAPSHOT</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
                 <plugin>
                     <groupId>com.github.cafapi.plugins.docker.versions</groupId>
                     <artifactId>docker-versions-maven-plugin</artifactId>
-                    <version>2.0.0-I941175-SNAPSHOT</version>
+                    <version>2.0.0-SNAPSHOT</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <DOCKER_HUB_PUBLIC>${dockerHubPublic}</DOCKER_HUB_PUBLIC>
         <enforceBannedDependencies>false</enforceBannedDependencies>
-        <projectDockerRegistry>opensuse-opensearch2-image-${project.version}.project-registries.local</projectDockerRegistry>
     </properties>
 
     <dependencyManagement>
@@ -172,6 +171,7 @@
                 <artifactId>docker-versions-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
+                    <projectDockerRegistry>opensuse-opensearch2-image-${project.version}.project-registries.local</projectDockerRegistry>
                     <imageManagement>
                         <image>
                             <repository>${dockerHubPublic}/cafapi/opensuse-jre21</repository>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=941175
This repository builds fine despite the "_" in the `projectRegistryName` because the `projectRegistryName` is only referenced in the Dockerfile with [resource filtering](https://github.com/fabric8io/docker-maven-plugin/blob/master/src/main/java/io/fabric8/maven/docker/util/DockerFileUtil.java#L152).